### PR TITLE
Added the two new damage flags in defs.scp:

### DIFF
--- a/core/defs.scp
+++ b/core/defs.scp
@@ -339,7 +339,9 @@ dam_pierce              00800   // damage done with spear and such.
 dam_nodisturb           02000   // victim won't be disturbed
 dam_noreveal            04000   // damage that does not reveal the attacker.
 dam_nounparalyze        08000   // victim won't be unparalyzed
-dam_fixed               010000	// damage will not be recalculated with default checks, lowering it because of armor, resistances ...
+dam_fixed               010000	// damage will not be recalculated with default checks, lowering it because of armor, resistances...
+dam_breath				020000	// damage source is from the NPC Breath action (brain_dragon only).
+dam_thrown				040000	// damage source is from the NPC Throw action, not to be confused with the Throwing skill.
 
 [DEFNAME can_i_flags]
 can_i_door				000001		// is a door uflag4_door


### PR DESCRIPTION
dam_breath				020000	// damage source is from the NPC Breath action (brain_dragon only).
dam_thrown				040000	// damage source is from the NPC Throw action, not to be confused with the Throwing skill.