### PR TITLE
Admin Menu- Fix special letter on Sysmessage

### DIFF
--- a/core/dialogs/admin/language_csy.scp
+++ b/core/dialogs/admin/language_csy.scp
@@ -160,18 +160,4 @@ d_admin_CSY_CountryName_NOR				"Norsko"
 d_admin_CSY_CountryName_TRK				"Turecko"
 d_admin_CSY_CountryName_LTH				"Litva"
 
-[DEFNAME defs_d_admin_Sysmessage_CSY]
-d_admin_CSY_Properties_Sys					"Vlastnosti"
-d_admin_CSY_Updated_Sys						"byly aktualizovány."
-d_admin_CSY_Allskills_Sys					"Všechny dovednosti"
-d_admin_CSY_Set_Sys						"byly nastaveny na"
-d_admin_CSY_Skills_Sys						"Dovednosti"
-d_admin_CSY_Flags_Sys						"Flagy"
-d_admin_CSY_Events_Sys						"Eventy"
-d_admin_CSY_Tags_Sys						"Tagy"
-d_admin_CSY_For_Account_Sys					"Pro úèet"
-d_admin_CSY_Added_Note_Sys					"byla pøidána poznámka."
-d_admin_CSY_Note_For_Account_Sys				"Záznam pro úèet"
-d_admin_CSY_Del_Note_Sys					"byl vymazán."
-
 [Eof]

--- a/core/dialogs/admin/language_deu.scp
+++ b/core/dialogs/admin/language_deu.scp
@@ -157,18 +157,4 @@ d_admin_DEU_CountryName_NOR				"Norwegen"
 d_admin_DEU_CountryName_TRK				"Truthahn"
 d_admin_DEU_CountryName_LTH				"Litauen"
 
-[DEFNAME defs_d_admin_Sysmessage_DEU]
-d_admin_DEU_Properties_Sys					"Eigenschaften"
-d_admin_DEU_Updated_Sys						"aktualisiert."
-d_admin_DEU_Allskills_Sys					"Alle Fähigkeiten"
-d_admin_DEU_Set_Sys						"wurden eingestellt"
-d_admin_DEU_Skills_Sys						"Fähigkeiten"
-d_admin_DEU_Flags_Sys						"Flagy"
-d_admin_DEU_Events_Sys						"Eventy"
-d_admin_DEU_Tags_Sys						"Tagy"
-d_admin_DEU_For_Account_Sys					"Für das Konto"
-d_admin_DEU_Added_Note_Sys					"eine Notiz wurde hinzugefügt."
-d_admin_DEU_Note_For_Account_Sys				"Notiz für Konto"
-d_admin_DEU_Del_Note_Sys					"wurde gelöscht."
-
 [Eof]

--- a/core/dialogs/admin/language_fra.scp
+++ b/core/dialogs/admin/language_fra.scp
@@ -157,18 +157,4 @@ d_admin_FRA_CountryName_NOR				"Norvège"
 d_admin_FRA_CountryName_TRK				"Turquie"
 d_admin_FRA_CountryName_LTH				"Lituanie"
 
-[DEFNAME defs_d_admin_Sysmessage_FRA]
-d_admin_FRA_Properties_Sys					"Propriétés"
-d_admin_FRA_Updated_Sys						"ont été mis à jour."
-d_admin_FRA_Allskills_Sys					"Toutes les compétences"
-d_admin_FRA_Set_Sys						"ont été définis sur"
-d_admin_FRA_Skills_Sys						"Compétences"
-d_admin_FRA_Flags_Sys						"Flags"
-d_admin_FRA_Events_Sys						"Événements"
-d_admin_FRA_Tags_Sys						"Balises"
-d_admin_FRA_For_Account_Sys					"Pour le compte"
-d_admin_FRA_Added_Note_Sys					"une note a été ajoutée."
-d_admin_FRA_Note_For_Account_Sys				"L'enregistrement du compte"
-d_admin_FRA_Del_Note_Sys					"a été supprimé."
-
 [Eof]

--- a/core/dialogs/admin/language_sky.scp
+++ b/core/dialogs/admin/language_sky.scp
@@ -157,18 +157,5 @@ d_admin_SKY_CountryName_NOR				"Nórsko"
 d_admin_SKY_CountryName_TRK				"Turecko"
 d_admin_SKY_CountryName_LTH				"Litva"
 
-[DEFNAME defs_d_admin_Sysmessage_SKY]
-d_admin_SKY_Properties_Sys					"Vlastnosti"
-d_admin_SKY_Updated_Sys						"boli aktualizované."
-d_admin_SKY_Allskills_Sys					"Všetky zruènosti"
-d_admin_SKY_Set_Sys						"boli nastavené na"
-d_admin_SKY_Skills_Sys						"Zruènosti"
-d_admin_SKY_Flags_Sys						"Flagy"
-d_admin_SKY_Events_Sys						"Eventy"
-d_admin_SKY_Tags_Sys						"Tagy"
-d_admin_SKY_For_Account_Sys					"Pre úèet"
-d_admin_SKY_Added_Note_Sys					"bola pridaná poznámka."
-d_admin_SKY_Note_For_Account_Sys				"Záznam pre úèet"
-d_admin_SKY_Del_Note_Sys					"bol vymazán."
 
 [Eof]

--- a/core/dialogs/admin/language_trk.scp
+++ b/core/dialogs/admin/language_trk.scp
@@ -156,18 +156,5 @@ d_admin_TRK_CountryName_NOR				"Norveç"
 d_admin_TRK_CountryName_TRK				"Türkiye"
 d_admin_TRK_CountryName_LTH				"Litvanya"
 
-[DEFNAME defs_d_admin_Sysmessage_TRK]
-d_admin_TRK_Properties_Sys					"Özellikler"
-d_admin_TRK_Updated_Sys						"Güncellendi"
-d_admin_TRK_Allskills_Sys					"Tüm Yetenekler
-d_admin_TRK_Set_Sys						"ayarlandý"
-d_admin_TRK_Skills_Sys						"Skills"
-d_admin_TRK_Flags_Sys						"Flags"
-d_admin_TRK_Events_Sys						"Events"
-d_admin_TRK_Tags_Sys						"Tags"
-d_admin_TRK_For_Account_Sys					"Hesap için"
-d_admin_TRK_Added_Note_Sys					"Bir not eklendi."
-d_admin_TRK_Note_For_Account_Sys				"Notlar"
-d_admin_TRK_Del_Note_Sys					"Silindi."
 
 [Eof]

--- a/core/dialogs/admin/sysmessage_admin.scp
+++ b/core/dialogs/admin/sysmessage_admin.scp
@@ -1,0 +1,84 @@
+//***********************************************************************************
+// SphereServer by: SphereServer development team and Menasoft.
+// www.sphereServer.net
+//***********************************************************************************
+// Save in ANSI encoding
+//***********************************************************************************
+// New Multilanguage Admin
+// Created by Golfin (http://eranova.cz/) and Jhobean (https://www.uocryptonite.com/)
+// Translated by Golfin, TRK Mirror_
+//***********************************************************************************
+//For an obscur reason, these defs need to be separate on a separate ANSI encoded  file. Avoid this make bug on sysmessage with special letter like é à ç á
+VERSION=X1
+
+[DEFNAME defs_d_admin_Sysmessage_CSY]
+d_admin_CSY_Properties_Sys					"Vlastnosti"
+d_admin_CSY_Updated_Sys						"byly aktualizovány."
+d_admin_CSY_Allskills_Sys					"Všechny dovednosti"
+d_admin_CSY_Set_Sys							"byly nastaveny na"
+d_admin_CSY_Skills_Sys						"Dovednosti"
+d_admin_CSY_Flags_Sys						"Flagy"
+d_admin_CSY_Events_Sys						"Eventy"
+d_admin_CSY_Tags_Sys						"Tagy"
+d_admin_CSY_For_Account_Sys					"Pro úèet"
+d_admin_CSY_Added_Note_Sys					"byla pøidána poznámka."
+d_admin_CSY_Note_For_Account_Sys			"Záznam pro úèet"
+d_admin_CSY_Del_Note_Sys					"byl vymazán."
+
+[DEFNAME defs_d_admin_Sysmessage_SKY]
+d_admin_SKY_Properties_Sys					"Vlastnosti"
+d_admin_SKY_Updated_Sys						"boli aktualizované."
+d_admin_SKY_Allskills_Sys					"Všetky zruènosti"
+d_admin_SKY_Set_Sys							"boli nastavené na"
+d_admin_SKY_Skills_Sys						"Zruènosti"
+d_admin_SKY_Flags_Sys						"Flagy"
+d_admin_SKY_Events_Sys						"Eventy"
+d_admin_SKY_Tags_Sys						"Tagy"
+d_admin_SKY_For_Account_Sys					"Pre úèet"
+d_admin_SKY_Added_Note_Sys					"bola pridaná poznámka."
+d_admin_SKY_Note_For_Account_Sys			"Záznam pre úèet"
+d_admin_SKY_Del_Note_Sys					"bol vymazán."
+
+[DEFNAME defs_d_admin_Sysmessage_DEU]
+d_admin_DEU_Properties_Sys					"Eigenschaften"
+d_admin_DEU_Updated_Sys						"aktualisiert."
+d_admin_DEU_Allskills_Sys					"Alle Fähigkeiten"
+d_admin_DEU_Set_Sys							"wurden eingestellt"
+d_admin_DEU_Skills_Sys						"Fähigkeiten"
+d_admin_DEU_Flags_Sys						"Flagy"
+d_admin_DEU_Events_Sys						"Eventy"
+d_admin_DEU_Tags_Sys						"Tagy"
+d_admin_DEU_For_Account_Sys					"Für das Konto"
+d_admin_DEU_Added_Note_Sys					"eine Notiz wurde hinzugefügt."
+d_admin_DEU_Note_For_Account_Sys			"Notiz für Konto"
+d_admin_DEU_Del_Note_Sys					"wurde gelöscht."
+
+[DEFNAME defs_d_admin_Sysmessage_TRK]
+d_admin_TRK_Properties_Sys					"Özellikler"
+d_admin_TRK_Updated_Sys						"Güncellendi"
+d_admin_TRK_Allskills_Sys					"Tüm Yetenekler
+d_admin_TRK_Set_Sys							"ayarlandý"
+d_admin_TRK_Skills_Sys						"Skills"
+d_admin_TRK_Flags_Sys						"Flags"
+d_admin_TRK_Events_Sys						"Events"
+d_admin_TRK_Tags_Sys						"Tags"
+d_admin_TRK_For_Account_Sys					"Hesap için"
+d_admin_TRK_Added_Note_Sys					"Bir not eklendi."
+d_admin_TRK_Note_For_Account_Sys				"Notlar"
+d_admin_TRK_Del_Note_Sys					"Silindi."
+
+[DEFNAME defs_d_admin_Sysmessage_FRA]
+d_admin_FRA_Properties_Sys					"Propriétés"
+d_admin_FRA_Updated_Sys						"ont été mis à jour."
+d_admin_FRA_Allskills_Sys					"Toutes les compétences"
+d_admin_FRA_Set_Sys							"ont été définis sur"
+d_admin_FRA_Skills_Sys						"Compétences"
+d_admin_FRA_Flags_Sys						"Flags"
+d_admin_FRA_Events_Sys						"Événements"
+d_admin_FRA_Tags_Sys						"Balises"
+d_admin_FRA_For_Account_Sys					"Pour le compte"
+d_admin_FRA_Added_Note_Sys					"une note a été ajoutée."
+d_admin_FRA_Note_For_Account_Sys			"L'enregistrement du compte"
+d_admin_FRA_Del_Note_Sys					"a été supprimé."
+
+[EOF]


### PR DESCRIPTION
This commit fix an obscur bug where sysmessage defname should be on a separate file encoded ANSI.

If we don't do that, special caracter do not show. On normal dialog, UTF8 encoding permit to see all caracter.