### PR TITLE
Add pet_release Dialog, bankbox weight and damage for player

### DIFF
--- a/core/dialogs/d_Pet_release.scp
+++ b/core/dialogs/d_Pet_release.scp
@@ -1,0 +1,35 @@
+//****************************************************************************
+// SphereServer by: SphereServer development team and Menasoft.
+// www.sphereserver.net
+//****************************************************************************
+VERSION=X1
+
+//This dialog can be desactivate by removing it or changing the name. If it's done
+//the server will no more ask this dialog before a pet release and will release automatically the pet.
+[DIALOG d_pet_release]
+50,50
+
+resizepic 0 0 5054 270 120
+IF (<FLAGS> & statf_dead)
+ dhtmlgump 10 10 250 75 1 0 <DEF.CENTER>Releasing a ghost pet will destroy it, with no chance of recovery.  Do you wish to continue?<DEF.CENTERE>
+ button 20 90 4005 4007 1 0 1
+ dhtmlgump 55 90 75 20 0 0 OKAY
+ button 135 90 4005 4007 1 0 0
+ dhtmlgump 170 90 75 20 0 0 CANCEL
+ELSE
+ resizepic 10 10 3000 250 100
+ dhtmlgump 20 15 230 60 1 1 Are you sure you want to release your pet? Summoned Pets will vanish permanently!
+ button 20 80 4005 4007 1 0 1
+ dhtmlgump 55 80 75 20 0 0 OKAY
+ button 135 80 4005 4007 1 0 0
+ dhtmlgump 170 80 75 20 0 0 CANCEL
+ENDIF
+
+[DIALOG d_pet_release BUTTON]
+ON=1
+IF !(<SRC.CANSEELOS <UID>>) || !(<ISMYPET>)
+ return 1
+ENDIF
+RELEASE
+
+[EOF]

--- a/items/i_unsorted.scp
+++ b/items/i_unsorted.scp
@@ -171,6 +171,7 @@ NAME=Bank Box
 LAYER=layer_bankbox
 TYPE=t_eq_bank_box
 TDATA2=04a
+WEIGHT=0
 
 
 [ITEMDEF 0b45]

--- a/npcs/c_monster_classic.scp
+++ b/npcs/c_monster_classic.scp
@@ -5311,6 +5311,7 @@ SOUND=snd_special_human
 ICON=i_pet_man
 CAN=mt_equip|mt_walk|mt_run|mt_usehands
 
+DAM=1,4
 HEIGHT=16
 RESPHYSICALMAX=70
 RESFIREMAX=70
@@ -5352,6 +5353,7 @@ CAN=mt_equip|mt_walk|mt_run|mt_female|mt_usehands
 SOUND=snd_special_human
 ICON=i_pet_woman
 
+DAM=1,4
 HEIGHT=16
 RESPHYSICALMAX=70
 RESFIREMAX=70

--- a/npcs/c_monster_ml.scp
+++ b/npcs/c_monster_ml.scp
@@ -1492,6 +1492,7 @@ NAME=Elf Male
 ICON=i_pet_MAN
 CAN=mt_equip|mt_walk|mt_run|mt_usehands
 
+DAM=1,4
 HEIGHT=16
 RESPHYSICALMAX=70
 RESFIREMAX=70
@@ -1527,6 +1528,7 @@ NAME=Elf Female
 ICON=i_pet_woman
 CAN=mt_equip|mt_walk|mt_run|mt_female|mt_usehands
 
+DAM=1,4
 HEIGHT=16
 RESPHYSICALMAX=70
 RESFIREMAX=70

--- a/npcs/c_monster_sa.scp
+++ b/npcs/c_monster_sa.scp
@@ -373,6 +373,7 @@ NAME=Gargoyle Male
 ICON=i_pet_man
 CAN=mt_equip|mt_walk|mt_run|mt_usehands
 
+DAM=1,4
 HEIGHT=16
 RESPHYSICALMAX=70
 RESFIREMAX=70
@@ -408,6 +409,7 @@ NAME=Gargoyle Female
 ICON=i_pet_woman
 CAN=mt_equip|mt_walk|mt_run|mt_usehands|mt_female
 
+DAM=1,4
 HEIGHT=16
 RESPHYSICALMAX=70
 RESFIREMAX=70


### PR DESCRIPTION
1- Add the Pet release Dialog require for the sphere X update
![image](https://user-images.githubusercontent.com/51728381/100956708-0c193380-34e7-11eb-8901-43cedbbbf10d.png)

This Dialog Is the same of OSI and it's ported from 56d (coruja dialog)


2- I set the backbox weight to 0. The new fixweight formula on the core include the weight of bankbox

3- I set damage for player corpse. C_man, C_elf and C_gargoyle.  When they doing wrestling, 0 damage was done