### PR TITLE
Modif: E_trainer event, TYPEDEF ei_equipitem and brain def

### DIFF
--- a/core/defs.scp
+++ b/core/defs.scp
@@ -40,6 +40,19 @@ brain_monster          8
 brain_berserk          9
 brain_dragon           10
 
+[DEFNAME NPCBrainNames]
+NPCBrain.0	brain_none
+NPCBrain.1	brain_animal
+NPCBrain.2	brain_human
+NPCBrain.3	brain_healer
+NPCBrain.4	brain_guard
+NPCBrain.5	brain_banker
+NPCBrain.6	brain_vendor
+NPCBrain.7	brain_animal_trainer
+NPCBrain.8	brain_monster
+NPCBrain.9	brain_berserk
+NPCBrain.10	brain_dragon
+
 [DEFNAME region_flags]
 region_antimagic_all			000001   // all magic banned here.
 region_antimagic_recall_in		000002   // teleport,recall in to this, and mark

--- a/events/e_human.scp
+++ b/events/e_human.scp
@@ -31,8 +31,9 @@ ON=@EnvironChange
 	return 0
 
 [EVENTS e_trainer]
-//This events is not use anymore because it's harcode on the Server since 2019/04
- ON=@ContextMenuRequest
+//The majority of skill training are set directly on server side
+//This event can be use to add some trainning skill
+// ON=@ContextMenuRequest
 //    IF (<NPC> < brain_human) || (<NPC> > brain_animal_trainer) || (<NPC> == brain_guard)
 //       return 0
 //    ENDIF

--- a/events/e_human.scp
+++ b/events/e_human.scp
@@ -31,24 +31,25 @@ ON=@EnvironChange
 	return 0
 
 [EVENTS e_trainer]
-ON=@ContextMenuRequest
-   IF (<NPC> < brain_human) || (<NPC> > brain_animal_trainer) || (<NPC> == brain_guard)
-      return 0
-   ENDIF
-   FOR 0 57
-      IF (<SERV.SKILL.<LOCAL._FOR>>)
-         LOCAL.NpcSkill = <<SERV.SKILL.<LOCAL._FOR>.KEY>>
-         IF (<LOCAL.NpcSkill>)
-            LOCAL.PlayerSkill = <SRC.<SERV.SKILL.<LOCAL._FOR>.KEY>>
-            LOCAL.Enabled = <QVAL ((<LOCAL.PlayerSkill> < <SERV.NPCTrainMax>) && (<eval (<LOCAL.NpcSkill> * <SERV.NPCTrainPercent>) / 100> > <LOCAL.PlayerSkill>)) ? 0 : 1>
-            SRC.ADDCONTEXTENTRY <eval 200 + <LOCAL._FOR>>,<eval 6000 + <LOCAL._FOR>>,<LOCAL.Enabled>
-         ENDIF
-      ENDIF
-   ENDFOR
-ON=@ContextMenuSelect
-   IF (<ARGN> >= 200) && (<ARGN> <= 257)
-      TRAIN <SERV.SKILL.<eval <ARGN>-200>.KEY>
-   ENDIF
-   
+//This events is not use anymore because it's harcode on the Server since 2019/04
+ ON=@ContextMenuRequest
+//    IF (<NPC> < brain_human) || (<NPC> > brain_animal_trainer) || (<NPC> == brain_guard)
+//       return 0
+//    ENDIF
+//    FOR 0 57
+//       IF (<SERV.SKILL.<LOCAL._FOR>>)
+//          LOCAL.NpcSkill = <<SERV.SKILL.<LOCAL._FOR>.KEY>>
+//          IF (<LOCAL.NpcSkill>)
+//             LOCAL.PlayerSkill = <SRC.<SERV.SKILL.<LOCAL._FOR>.KEY>>
+//             LOCAL.Enabled = <QVAL ((<LOCAL.PlayerSkill> < <SERV.NPCTrainMax>) && (<eval (<LOCAL.NpcSkill> * <SERV.NPCTrainPercent>) / 100> > <LOCAL.PlayerSkill>)) ? 0 : 1>
+//             SRC.ADDCONTEXTENTRY <eval 200 + <LOCAL._FOR>>,<eval 6000 + <LOCAL._FOR>>,<LOCAL.Enabled>
+//          ENDIF
+//       ENDIF
+//    ENDFOR
+// ON=@ContextMenuSelect
+//    IF (<ARGN> >= 200) && (<ARGN> <= 257)
+//       TRAIN <SERV.SKILL.<eval <ARGN>-200>.KEY>
+//    ENDIF
+
    [EOF]
    

--- a/types/type_equipitem.scp
+++ b/types/type_equipitem.scp
@@ -511,30 +511,31 @@ IF (<HasComponentProps <def.CompProps_ItemEquippable>>)
 			// SRC.SYSMESSAGELOC <def.color_text>,1079552//"Your luck just ran out."
 		// ENDIF
 	// ENDIF
-	IF (<BonusStr>)//strength bonus
-		SRC.MODSTR += <BonusStr>
-	ENDIF
-	IF (<BonusHitsMax>)//hitpoint increase
-		SRC.MODMAXHITS += <BonusHitsMax>
-	ENDIF
+
+	// IF (<BonusStr>)//strength bonus
+	// 	SRC.MODSTR += <BonusStr>
+	// ENDIF
+	// IF (<BonusHitsMax>)//hitpoint increase
+	// 	SRC.MODMAXHITS += <BonusHitsMax>
+	// ENDIF
 	IF (<RegenHits>)
 		SRC.RegenHits += <RegenHits>
 	ENDIF
-	IF (<BonusDex>)//dexterity bonus
-		SRC.MODDEX += <BonusDex>
-	ENDIF
-	IF (<BonusStamMax>)//stamina increase
-		SRC.MODMAXSTAM += <BonusStamMax>
-	ENDIF
+	// IF (<BonusDex>)//dexterity bonus
+	// 	SRC.MODDEX += <BonusDex>
+	// ENDIF
+	// IF (<BonusStamMax>)//stamina increase
+	// 	SRC.MODMAXSTAM += <BonusStamMax>
+	// ENDIF
 	IF (<RegenStam>)
 		SRC.RegenStam += <RegenStam>
 	ENDIF
-	IF (<BonusINT>)//intelligence bonus
-		SRC.MODINT += <BonusINT>
-	ENDIF
-	IF (<BonusManaMax>)//mana increase
-		SRC.MODMAXMANA <BonusManaMax>
-	ENDIF
+	// IF (<BonusINT>)//intelligence bonus
+	// 	SRC.MODINT += <BonusINT>
+	// ENDIF
+	//IF (<BonusManaMax>)//mana increase
+	//	SRC.MODMAXMANA <BonusManaMax>
+	//ENDIF
 	IF (<RegenMana>)//alters the "rate" of mana regeneration
 		SRC.RegenMana += <RegenMana>
 	ENDIF
@@ -708,30 +709,30 @@ IF (<HasComponentProps <def.CompProps_ItemEquippable>>)
 		// ENDIF
 		// SRC.LUCK -= <LUCK>
 	// ENDIF
-	IF (<BonusStr>)//strength bonus
-		SRC.MODSTR -= <BonusStr>
-	ENDIF
-	IF (<BonusHitsMax>)//hitpoint increase
-		SRC.MODMAXHITS -= <BonusHitsMax>
-	ENDIF
+	// IF (<BonusStr>)//strength bonus
+	// 	SRC.MODSTR -= <BonusStr>
+	// ENDIF
+	// IF (<BonusHitsMax>)//hitpoint increase
+	// 	SRC.MODMAXHITS -= <BonusHitsMax>
+	// ENDIF
 	IF (<RegenHits>)
 		SRC.RegenHits -= <RegenHits>
 	ENDIF
-	IF (<BonusDex>)//dexterity bonus
-		SRC.MODDEX -= <BonusDex>
-	ENDIF
-	IF (<BonusStamMax>)//stamina increase
-		SRC.MODMAXSTAM -= <BonusStamMax>
-	ENDIF
+	// IF (<BonusDex>)//dexterity bonus
+	// 	SRC.MODDEX -= <BonusDex>
+	// ENDIF
+	// IF (<BonusStamMax>)//stamina increase
+	// 	SRC.MODMAXSTAM -= <BonusStamMax>
+	// ENDIF
 	IF (<RegenStam>)
 		SRC.RegenStam -= <RegenStam>
 	ENDIF
-	IF (<BonusINT>)//intelligence bonus
-		SRC.MODINT -= <BonusINT>
-	ENDIF
-	IF (<BonusManaMax>)//mana increase
-		SRC.MODMAXMANA -= <BonusManaMax>
-	ENDIF
+	// IF (<BonusINT>)//intelligence bonus
+	// 	SRC.MODINT -= <BonusINT>
+	// ENDIF
+	// IF (<BonusManaMax>)//mana increase
+	// 	SRC.MODMAXMANA -= <BonusManaMax>
+	// ENDIF
 	IF (<RegenMana>)
 		SRC.RegenMana -= <RegenMana>
 	ENDIF


### PR DESCRIPTION
Since 2019, it's now harcoded: https://github.com/Sphereserver/Source-X/blob/1637a85df5b78779ef67398f107241af80cbe12b/Changelog-X1-Nightlies.txt#L1619

With this event, the context menu was open 2 times

![image](https://user-images.githubusercontent.com/51728381/104925955-8144a900-596d-11eb-863a-eb559080995c.png)
 

Plus:
1- I added some def for the charprop dialog. 

2- Removed some item propoerty now done by server
